### PR TITLE
🔧 Make sure dynamic customer categories possible

### DIFF
--- a/api-tests/client_simulator_api_tests.py
+++ b/api-tests/client_simulator_api_tests.py
@@ -1,25 +1,18 @@
 """ Use this to simulate client requests in the API tests"""
 import random
 from time import sleep
-
 import requests
 from numpy.random import normal
-
 from config import BASE_URL
-from utils import get_currently_active_process_id
+from utils import get_currently_active_process_id, get_currently_active_process_meta
 
-CUSTOMER_CATEGORIES = ["public", "gov"]
 NORMAL_DIST_STD_DEV = 0.1
 
 
-def _get_random_customer_category():
-    return CUSTOMER_CATEGORIES[random.randint(0, len(CUSTOMER_CATEGORIES) - 1)]
-
-
-def send_request_for_new_processes_instance(process_id):
+def send_request_for_new_processes_instance(process_id, customer_categories):
     params = {
         "process-id": process_id,
-        "customer-category": _get_random_customer_category()
+        "customer-category": customer_categories[random.randint(0, len(customer_categories) - 1)]
     }
     response = requests.get(BASE_URL + "/instance-router/start-instance", params=params)
     assert response.status_code == requests.codes.ok
@@ -27,9 +20,10 @@ def send_request_for_new_processes_instance(process_id):
 
 
 def start_client_simulation(amount_of_requests_to_send: int, avg_break_sec: float):
+    customer_categories = get_currently_active_process_meta().get('customer_categories').split('-')
     currently_active_p_id = get_currently_active_process_id()
     for i in range(amount_of_requests_to_send):
-        send_request_for_new_processes_instance(currently_active_p_id)
+        send_request_for_new_processes_instance(currently_active_p_id, customer_categories)
         normal_sample = normal(avg_break_sec, NORMAL_DIST_STD_DEV)
         sleep_value = normal_sample if normal_sample >= 0 else 0
         sleep(sleep_value)

--- a/api-tests/utils.py
+++ b/api-tests/utils.py
@@ -67,19 +67,19 @@ example_batch_policy = {
     }
 
 
-def example_batch_policy_size(size: int) -> dict:
+def example_batch_policy_size(size: int, customer_categories: list) -> dict:
     return {
         "batchSize": size,
         "executionStrategy": [
             {
-                "customerCategory": "public",
-                "explorationProbabilityA": 0.3,
-                "explorationProbabilityB": 0.7
-            },
-            {
-                "customerCategory": "gov",
+                "customerCategory": customer_categories[0],
                 "explorationProbabilityA": 0.7,
                 "explorationProbabilityB": 0.3
+            },
+            {
+                "customerCategory": customer_categories[1],
+                "explorationProbabilityA": 0.3,
+                "explorationProbabilityB": 0.7
             }
         ]
     }

--- a/client_simulator/client_simulator.py
+++ b/client_simulator/client_simulator.py
@@ -1,11 +1,10 @@
 import random
 from time import sleep
-
 import requests
 from numpy.random import normal
 
 BASE_URL = "http://localhost:5001"
-CUSTOMER_CATEGORIES = ["public", "gov"]
+CUSTOMER_CATEGORIES = None  # TODO: set these before starting
 AMOUNT_OF_REQUESTS_TO_SEND = 10
 NORMAL_DIST_MEAN = 1
 NORMAL_DIST_STD_DEV = 0.5

--- a/source/frontend/client_simulator.py
+++ b/source/frontend/client_simulator.py
@@ -4,21 +4,12 @@ from time import sleep
 import requests
 from numpy.random import normal
 from config import BACKEND_URI
-from utils import get_currently_active_process_id
+from utils import get_currently_active_process_id, get_currently_active_process_meta
 
-CUSTOMER_CATEGORIES = ["public", "gov"]
 NORMAL_DIST_STD_DEV = 0.5
 
 
-def _get_random_customer_category() -> str:
-    """Get random customer category
-
-    :return: "public" or "gov"
-    """
-    return CUSTOMER_CATEGORIES[random.randint(0, len(CUSTOMER_CATEGORIES) - 1)]
-
-
-def _send_request_for_new_processes_instance(process_id) -> str:
+def _send_request_for_new_processes_instance(process_id:int, customer_categories: list) -> str:
     """Send a request for a new process instance
 
     :param process_id: specify process
@@ -26,7 +17,7 @@ def _send_request_for_new_processes_instance(process_id) -> str:
     """
     params = {
         "process-id": process_id,
-        "customer-category": _get_random_customer_category()
+        "customer-category": customer_categories[random.randint(0, len(customer_categories) - 1)]
     }
     response = requests.get(BACKEND_URI + "/instance-router/start-instance", params=params)
     assert response.status_code == requests.codes.ok  # pylint: disable=no-member
@@ -39,9 +30,10 @@ def run_simulation(amount_of_requests: int, avg_interarrival_time: float) -> Non
     :param amount_of_requests: How many requests should be sent out
     :param avg_interarrival_time: Average time between instantiation requests
     """
+    customer_categories = get_currently_active_process_meta().get('customer_categories').split('-')
     currently_active_p_id = get_currently_active_process_id()
     for _ in range(amount_of_requests):
-        print(_send_request_for_new_processes_instance(currently_active_p_id))
+        print(_send_request_for_new_processes_instance(currently_active_p_id, customer_categories))
         normal_sample = normal(avg_interarrival_time, NORMAL_DIST_STD_DEV)
         sleep_value = normal_sample if normal_sample >= 0 else 0
         sleep(sleep_value)

--- a/source/frontend/sidebar/__init__.py
+++ b/source/frontend/sidebar/__init__.py
@@ -12,5 +12,5 @@ def build_bar():
     - Controllable: Expert oversight (Human-in-the-Loop)
     
     For reporting bugs, feedback and more info, please refer
-     to the [Github repository](https://github.com/Ultimate-Storm/sbe_prototyping).
+     to the [Github repository](https://github.com/aaronkurz/hitl-ab-bpm).
     """)


### PR DESCRIPTION
## Ticket

Closes #118.

## Notes for Reviewers

Made many API tests also test for a second set of customer categories to make sure that the prototype also allows for other customer categories than public and gov. Also modified client simulators to be dynamic.

## Definition of Done

- [X] Code manually tested
- [ ] Unit tests written N/A
- [X] API tests written
- [ ] Code commented N/A
- [ ] Documentation written N/A
